### PR TITLE
SERVER-44090 Upgrade SafeInt to 3.23

### DIFF
--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -1051,7 +1051,7 @@ public:
         return (T)SignedNegation<std::int64_t>::Value(t);
     }
 
-    _CONSTEXPR14 static bool Negative(T t, T& /*out*/)
+    _CONSTEXPR14 static bool Negative(T , T& /*out*/)
     {
         // This will only be used by the SafeNegation function
         return false;

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -3,7 +3,7 @@
 
 /*-----------------------------------------------------------------------------------------------------------
 SafeInt.hpp
-Version 3.0.20p
+Version 3.0.21p
 
 This header implements an integer handling class designed to catch
 unsafe integer operations

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -3,7 +3,7 @@
 
 /*-----------------------------------------------------------------------------------------------------------
 SafeInt.hpp
-Version 3.0.22p
+Version 3.0.23p
 
 This header implements an integer handling class designed to catch
 unsafe integer operations
@@ -565,6 +565,7 @@ SIZE_T_CAST_NEEDED                 - some compilers complain if there is not a c
 *
 */
 
+// Warning - this very old work-around will be deprecated in future releases. 
 #if defined VISUAL_STUDIO_SAFEINT_COMPAT
 namespace msl
 {
@@ -7116,10 +7117,9 @@ _CONSTEXPR11 SafeInt< T, E > operator |( U lhs, SafeInt< T, E > rhs ) SAFEINT_NO
     return SafeInt< T, E >( BinaryOrHelper< T, U, BinaryMethod< T, U >::method >::Or( (T)rhs, lhs ) );
 }
 
-#endif //SAFEINT_HPP
-
 #if defined VISUAL_STUDIO_SAFEINT_COMPAT
 } // utilities
 } // msl
 #endif
 
+#endif //SAFEINT_HPP

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -1024,6 +1024,17 @@ public:
         }
         E::SafeIntOnOverflow();
     }
+
+    _CONSTEXPR14 static bool Negative(T t, T& out)
+    {
+        // corner case
+        if (t != std::numeric_limits<T>::min())
+        {
+            out = -t;
+            return true;
+        }
+        return false;
+    }
 };
 
 template < typename T > class NegationHelper <T, false> // unsigned
@@ -1039,6 +1050,11 @@ public:
         return (T)SignedNegation<std::int64_t>::Value(t);
     }
 
+    _CONSTEXPR14 static bool Negative(T t, T& /*out*/)
+    {
+        // This will only be used by the SafeNegation function
+        return false;
+    }
 };
 
 //core logic to determine casting behavior
@@ -5595,6 +5611,12 @@ template < typename T, typename U >
 _CONSTEXPR11 inline bool SafeSubtract( T t, U u, T& result ) SAFEINT_NOTHROW
 {
     return SubtractionHelper< T, U, SubtractionMethod< T, U >::method >::Subtract( t, u, result );
+}
+
+template < typename T >
+_CONSTEXPR11 inline bool SafeNegation(T t, T& result) SAFEINT_NOTHROW
+{
+    return NegationHelper< T, std::numeric_limits<T>::is_signed>::Negative(t, result);
 }
 
 /*****************  end external functions ************************************/

--- a/SafeInt.hpp
+++ b/SafeInt.hpp
@@ -3,7 +3,7 @@
 
 /*-----------------------------------------------------------------------------------------------------------
 SafeInt.hpp
-Version 3.0.21p
+Version 3.0.22p
 
 This header implements an integer handling class designed to catch
 unsafe integer operations
@@ -1833,7 +1833,7 @@ public:
     //accepts unsigned, both less than 32-bit
     _CONSTEXPR14 static bool Multiply( const T& t, const U& u, T& ret ) SAFEINT_NOTHROW
     {
-        unsigned int tmp = (unsigned int)(t * u);
+        unsigned int tmp = (unsigned int)t * (unsigned int)u;
 
         if( tmp > std::numeric_limits<T>::max() )
             return false;

--- a/Test/ClangTest/.gitignore
+++ b/Test/ClangTest/.gitignore
@@ -1,2 +1,3 @@
 SafeIntTest
 CompileTest
+CompileTest14

--- a/Test/ClangTest/.gitignore
+++ b/Test/ClangTest/.gitignore
@@ -1,3 +1,4 @@
+*.err
 SafeIntTest
 CompileTest
 CompileTest14

--- a/Test/ClangTest/makefile
+++ b/Test/ClangTest/makefile
@@ -9,7 +9,7 @@ clean:
 	rm -f *.err
 
 SafeIntTest: ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp ../TestMain.h ../../SafeInt.hpp
-	clang++ --std=c++11 -O3 ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest 2> SafeIntTest.err
+	clang++ --std=c++11 -O3 -fsanitize=undefined -ftrapv ../AddVerify.cpp ../CastVerify.cpp ../DivVerify.cpp ../IncDecVerify.cpp ../ModVerify.cpp ../MultVerify.cpp ../SubVerify.cpp ../TestMain.cpp -o SafeIntTest 2> SafeIntTest.err
 
 CompileTest: ../CompileTest.cpp ../../SafeInt.hpp ../ConstExpr.cpp ../CleanCompile.cpp
 	clang++ -Wall --std=c++11 -O3 ../CompileTest.cpp ../ConstExpr.cpp ../CleanCompile.cpp -o CompileTest 2> CompileTest.err

--- a/Test/CompileTest.cpp
+++ b/Test/CompileTest.cpp
@@ -247,6 +247,13 @@ void CompileType()
 	st--;
 	--st;
 	t = ~st;
+
+	// Get compile time coverage of negation
+	T x = 1;
+	T result;
+
+	SafeNegation(x, result);
+
 }
 
 void CompileMe()

--- a/Test/ConstExpr.cpp
+++ b/Test/ConstExpr.cpp
@@ -407,8 +407,11 @@ namespace TestConstExpr
 		static_assert(SafeInt<T>((T)3) / (U)2, "Division");
 		static_assert(SafeInt<T>((T)3) / SafeInt<T>(2), "Division");
 		static_assert((SafeInt<T>((T)3) /= (U)2), "Division");
+#if SAFEINT_COMPILER != GCC_COMPILER
+		// gcc is not happy with this one
 		static_assert((SafeInt<T>((T)3) /= SafeInt<U>(2)), "Division");
 		static_assert((U)3 / SafeInt<T>(2), "Division");
+#endif
 		static_assert(DivOperator<T,U>(), "Division");
 
 		// Addition

--- a/Test/GccTest/.gitignore
+++ b/Test/GccTest/.gitignore
@@ -1,2 +1,4 @@
+*.err
 SafeIntTest
 CompileTest
+CompileTest14

--- a/Test/SafeIntTestVS17/CompileTest/CompileTest.vcxproj
+++ b/Test/SafeIntTestVS17/CompileTest/CompileTest.vcxproj
@@ -22,32 +22,32 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{1E55B5E4-2A0D-4782-82E7-58F508A7CC80}</ProjectGuid>
     <RootNamespace>CompileTest</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Test/SafeIntTestVS17/SafeIntTestVS17/SafeIntTestVS17.vcxproj
+++ b/Test/SafeIntTestVS17/SafeIntTestVS17/SafeIntTestVS17.vcxproj
@@ -22,32 +22,32 @@
     <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{1D3628DA-8471-4F50-86B6-3B04B3CC6D5F}</ProjectGuid>
     <RootNamespace>SafeIntTestVS17</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Test/SubVerify.cpp
+++ b/Test/SubVerify.cpp
@@ -6955,3 +6955,65 @@ void SubVerify()
 }
 
 }
+
+namespace negation_verify
+{
+    template < typename T >
+    void NegationVerifyT()
+    {
+        T minInt = std::numeric_limits<T>::min();
+        T test = 2;
+        bool result = false;
+        T out = 0;
+
+        try
+        {
+            out = -SafeInt< T >(minInt);
+        }
+        catch (...)
+        {
+            result = true;
+        }
+
+        if (result == false)
+            cerr << "Error in NegationVerifyT throw (1): ";
+
+        try
+        {
+            out = -SafeInt< T >(test);
+        }
+        catch (...)
+        {
+            result = false;
+        }
+
+        if (result == false)
+            cerr << "Error in NegationVerifyT throw (2): ";
+
+        // Now try the non-throwing version
+
+        result = SafeNegation(minInt, out);
+
+        if (result != false)
+            cerr << "Error in NegationVerifyT nothrow (1): ";
+
+        result = SafeNegation(test, out);
+
+        if (result == false)
+            cerr << "Error in NegationVerifyT nothrow (2): ";
+    }
+
+    void NegationVerifyAll()
+    {
+        NegationVerifyT< std::int8_t>();
+        NegationVerifyT< std::int16_t>();
+        NegationVerifyT< std::int32_t>();
+        NegationVerifyT< std::int64_t>();
+    }
+
+    void NegationVerify()
+    {
+        cout << "Verifying Negation:" << endl;
+        NegationVerifyAll();
+    }
+}

--- a/Test/TestMain.cpp
+++ b/Test/TestMain.cpp
@@ -9,13 +9,13 @@
 
 int main(int, char**)
 {
-	cast_verify::CastVerify();
-	mult_verify::MultVerify();
-	div_verify::DivVerify();
-	sub_verify::SubVerify();
-	add_verify::AddVerify();
-	mod_verify::ModVerify();
-	incdec_verify::IncDecVerify();
-   
-	return 0;
+    cast_verify::CastVerify();
+    mult_verify::MultVerify();
+    div_verify::DivVerify();
+    sub_verify::SubVerify();
+    add_verify::AddVerify();
+    mod_verify::ModVerify();
+    incdec_verify::IncDecVerify();
+    negation_verify::NegationVerify();
+    return 0;
 }

--- a/Test/TestMain.h
+++ b/Test/TestMain.h
@@ -26,8 +26,8 @@ using std::dec;
 
 // Suppress warnings in test files, but not in source header
 #if SAFEINT_COMPILER == VISUAL_STUDIO_COMPILER
-
-#pragma warning(disable: 4838 4477 4310)
+// Disable Spectre mitigation warnings (5045)
+#pragma warning(disable: 4838 4477 4310 5045)
 #elif SAFEINT_COMPILER == CLANG_COMPILER 
 #pragma GCC diagnostic ignored "-Wc++11-narrowing"
 #pragma GCC diagnostic ignored "-Wformat"
@@ -52,4 +52,5 @@ namespace add_verify { void AddVerify(); }
 namespace mod_verify { void ModVerify(); }
 namespace incdec_verify { void IncDecVerify(); }
 namespace cast_verify { void CastVerify(); }
+namespace negation_verify { void NegationVerify(); }
 


### PR DESCRIPTION
Upgrade SafeInt to version 3.23. This release adds support for safe negation and fixes some undefined behavior in nonstandard int multiplication.